### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/vilui/86f3a5ab-f49d-46ec-8a28-3ec1d4279e63/2bbcd97c-9d10-44c3-a6f3-38fec478239b/_apis/work/boardbadge/ec7ea42d-48ff-4a6c-b40e-68e15e9dee02)](https://dev.azure.com/vilui/86f3a5ab-f49d-46ec-8a28-3ec1d4279e63/_boards/board/t/2bbcd97c-9d10-44c3-a6f3-38fec478239b/Microsoft.RequirementCategory)
 # silver-engine
 
 Welcome!


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/vilui/86f3a5ab-f49d-46ec-8a28-3ec1d4279e63/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.